### PR TITLE
Refactor: Rename storage variable to AsyncStorage in documentation for consistency

### DIFF
--- a/.changeset/grumpy-results-allow.md
+++ b/.changeset/grumpy-results-allow.md
@@ -1,0 +1,6 @@
+---
+"@stork-tools/zod-async-storage": patch
+"@stork-tools/zod-local-storage": patch
+---
+
+Update READMEs for clarity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,13 +138,13 @@ describe('createAsyncStorage', () => {
 
   it('should validate data when storing values', async () => {
     // Arrange
-    const storage = createAsyncStorage({
+    const AsyncStorage = createAsyncStorage({
       user: z.object({ name: z.string() })
     });
 
     // Act & Assert
     await expect(
-      storage.setItem('user', { name: 123 })
+      AsyncStorage.setItem('user', { name: 123 })
     ).rejects.toThrow('Invalid data');
   });
 });

--- a/packages/zod-async-storage/README.md
+++ b/packages/zod-async-storage/README.md
@@ -52,8 +52,10 @@ const schemas = {
   }),
 };
 
-// Create type-safe storage
-const AsyncStorage = createAsyncStorage(schemas);
+// Create a single instance of type-safe storage
+export const AsyncStorage = createAsyncStorage(schemas);
+
+import { AsyncStorage } from "~/async-storage";
 
 // Use with full type safety
 await AsyncStorage.setItem("user", {
@@ -166,7 +168,10 @@ const schemas = {
   }),
 };
 
-const AsyncStorage = createAsyncStorage(schemas);
+// Create a single instance of type-safe storage
+export const AsyncStorage = createAsyncStorage(schemas);
+
+import { AsyncStorage } from "~/async-storage";
 
 // Set data
 await AsyncStorage.setItem("user", {
@@ -201,7 +206,7 @@ await AsyncStorage.getItem("someUndefinedKey");   // ❌ TypeScript error
 Disable strict mode to allow access to any key while maintaining type safety for schema-defined keys. This is useful if you are migrating to `@stork-tools/zod-async-storage` and want to maintain access to keys that are not yet defined in schemas.
 
 ```ts
-const storage = createAsyncStorage(schemas, { strict: false });
+const AsyncStorage = createAsyncStorage(schemas, { strict: false });
 
 await AsyncStorage.getItem("user");      // Type: User | null (validated)
 await AsyncStorage.getItem("any-key");   // Type: string | null (loose autocomplete, no validation)
@@ -218,10 +223,10 @@ Configure how validation failures are handled:
 
 ```ts
 // Clear invalid data (default)
-const storage = createAsyncStorage(schemas, { onFailure: "clear" });
+const AsyncStorage = createAsyncStorage(schemas, { onFailure: "clear" });
 
 // Throw errors on invalid data
-const storage = createAsyncStorage(schemas, { onFailure: "throw" });
+const AsyncStorage = createAsyncStorage(schemas, { onFailure: "throw" });
 
 // Per-operation override
 const user = await AsyncStorage.getItem("user", { onFailure: "throw" });
@@ -232,7 +237,7 @@ const user = await AsyncStorage.getItem("user", { onFailure: "throw" });
 Get notified when validation fails using the `onValidationError` callback:
 
 ```ts
-const storage = createAsyncStorage(schemas, {
+const AsyncStorage = createAsyncStorage(schemas, {
   onFailure: "clear",
   onValidationError: (key, error, value) => {
     // Log validation failures for monitoring
@@ -248,7 +253,7 @@ const storage = createAsyncStorage(schemas, {
 });
 
 // Per-operation callback override
-const user = await storage.getItem("user", {
+const user = await AsyncStorage.getItem("user", {
   onValidationError: (key, error, value) => {
     // Handle this specific validation error differently
     showUserErrorMessage(`Invalid user data: ${error.message}`);
@@ -285,8 +290,8 @@ await AsyncStorage.setItem("token", "abc123");         // Raw string
 ```ts
 import { createAsyncStorage, createUseAsyncStorage } from "@stork-tools/zod-async-storage";
 
-const storage = createAsyncStorage(schemas);
-const { useAsyncStorage } = createUseAsyncStorage(storage);
+const AsyncStorage = createAsyncStorage(schemas);
+const { useAsyncStorage } = createUseAsyncStorage(AsyncStorage);
 
 function UserProfile() {
   const { getItem, setItem, mergeItem, removeItem } = useAsyncStorage("user");
@@ -325,7 +330,7 @@ All methods support the same options and callbacks as the storage instance.
 Enable debug logging to monitor validation failures:
 
 ```ts
-const storage = createAsyncStorage(schemas, {
+export const AsyncStorage = createAsyncStorage(schemas, {
   debug: true,
   onFailure: "clear",
 });

--- a/packages/zod-local-storage/README.md
+++ b/packages/zod-local-storage/README.md
@@ -52,8 +52,10 @@ const schemas = {
   }),
 };
 
-// Create type-safe storage
-const localStorage = createLocalStorage(schemas);
+// Create a single instance of type-safe storage
+export const localStorage = createLocalStorage(schemas);
+
+import { localStorage } from "~/local-storage";
 
 // Use with full type safety
 localStorage.setItem("user", {
@@ -168,7 +170,10 @@ const schemas = {
   }),
 };
 
-const localStorage = createLocalStorage(schemas);
+// Create a single instance of type-safe storage
+export const localStorage = createLocalStorage(schemas);
+
+import { localStorage } from "~/local-storage";
 
 // Set data
 localStorage.setItem("user", {
@@ -203,7 +208,7 @@ localStorage.getItem("someUndefinedKey");   // ❌ TypeScript error
 Disable strict mode to allow access to any key while maintaining type safety for schema-defined keys. This is useful if you are migrating to `@stork-tools/zod-local-storage` and want to maintain access to keys that are not yet defined in schemas.
 
 ```ts
-const storage = createLocalStorage(schemas, { strict: false });
+const localStorage = createLocalStorage(schemas, { strict: false });
 
 localStorage.getItem("user");      // Type: User | null (validated)
 localStorage.getItem("any-key");   // Type: string | null (loose autocomplete, no validation)
@@ -220,10 +225,10 @@ Configure how validation failures are handled:
 
 ```ts
 // Clear invalid data (default)
-const storage = createLocalStorage(schemas, { onFailure: "clear" });
+const localStorage = createLocalStorage(schemas, { onFailure: "clear" });
 
 // Throw errors on invalid data
-const storage = createLocalStorage(schemas, { onFailure: "throw" });
+const localStorage = createLocalStorage(schemas, { onFailure: "throw" });
 
 // Per-operation override
 const user = localStorage.getItem("user", { onFailure: "throw" });
@@ -234,7 +239,7 @@ const user = localStorage.getItem("user", { onFailure: "throw" });
 Get notified when validation fails using the `onValidationError` callback:
 
 ```ts
-const storage = createLocalStorage(schemas, {
+const localStorage = createLocalStorage(schemas, {
   onFailure: "clear",
   onValidationError: (key, error, value) => {
     // Log validation failures for monitoring
@@ -250,7 +255,7 @@ const storage = createLocalStorage(schemas, {
 });
 
 // Per-operation callback override
-const user = storage.getItem("user", {
+const user = localStorage.getItem("user", {
   onValidationError: (key, error, value) => {
     // Handle this specific validation error differently
     showUserErrorMessage(`Invalid user data: ${error.message}`);
@@ -286,8 +291,8 @@ localStorage.setItem("token", "abc123");         // Raw string
 ```ts
 import { createLocalStorage, createUseLocalStorage } from "@stork-tools/zod-local-storage";
 
-const storage = createLocalStorage(schemas);
-const { useLocalStorage } = createUseLocalStorage(storage);
+const localStorage = createLocalStorage(schemas);
+const { useLocalStorage } = createUseLocalStorage(localStorage);
 
 function UserProfile() {
   const { getItem, setItem, removeItem } = useLocalStorage("user");
@@ -321,7 +326,7 @@ All methods support the same options as the storage instance.
 Enable debug logging to monitor validation failures:
 
 ```ts
-const storage = createLocalStorage(schemas, {
+export const localStorage = createLocalStorage(schemas, {
   debug: true,
   onFailure: "clear",
 });


### PR DESCRIPTION
## 📝 Description

Update READMEs for clarity

## 🔗 Related Issue

<!-- Link to the issue this PR addresses, if applicable -->
Closes #(issue number)

## 📦 Changeset

<!-- For code changes that affect users -->
- [X] Added changeset (`pnpm changeset`)